### PR TITLE
Add regression tests for shaping issues

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -83,7 +83,7 @@ jobs:
       uses: f-actions/font-bakery@v1
       with:
         subcmd: "check-profile"
-        args: "--config fontbakery.yml --ghmarkdown reports/fontbakery/${{ matrix.font-family }}-shaping.html fontbakery.profiles.shaping"
+        args: "--config fontbakery.yml --html reports/fontbakery/${{ matrix.font-family }}-shaping.html fontbakery.profiles.shaping"
         path: "builds/variable_ttf/${{ matrix.font-family }}-VF.ttf"
     - name: Store Fontbakery reports
       uses: actions/upload-artifact@v1

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -79,6 +79,12 @@ jobs:
         subcmd: "check-opentype"
         args: "-x monospace -x glyf_nested_components -x fontbakery_version -x dsig --loglevel WARN --ghmarkdown reports/fontbakery/${{ matrix.font-family }}.md"
         path: "builds/variable_ttf/${{ matrix.font-family }}-VF.ttf"
+    - name: Fontbakery shaping checks ${{ matrix.font-family }}
+      uses: f-actions/font-bakery@v1
+      with:
+        subcmd: "check-profile"
+        args: "--config fontbakery.yml --ghmarkdown reports/fontbakery/${{ matrix.font-family }}-shaping.html fontbakery.profiles.shaping"
+        path: "builds/variable_ttf/${{ matrix.font-family }}-VF.ttf"
     - name: Store Fontbakery reports
       uses: actions/upload-artifact@v1
       with:

--- a/fontbakery.yml
+++ b/fontbakery.yml
@@ -1,0 +1,2 @@
+com.google.fonts/check/shaping:
+    test_directory: test

--- a/test/shaping.json
+++ b/test/shaping.json
@@ -1,0 +1,16 @@
+{
+	"tests": [
+		{
+			"note": "Check that mark position is working correctly (see googlefonts/noto-source#379)",
+			"only": "NotoLoopedLao-VF.ttf",
+			"input": "ວິດ",
+			"expectation": "uni0EA7=0+617|uni0EB4=0@-596,0+0|uni0E94=2+684"
+		},
+		{
+			"note": "Check that manual and automatic belowmarks position well (see googlefonts/noto-source#377)",
+			"only": "NotoLoopedLao-VF.ttf",
+			"input": "ກຼຸ່",
+			"expectation": "uni0E81=0+721|uni0EBC=0@-578,0+0|uni0EB8.small=0@-433,-42+0|uni0EC8=0@-430,0+0"
+		}
+	]
+}


### PR DESCRIPTION
See issues described in googlefonts/noto-source#377 and googlefonts/noto-source#379.

@marekjez86, I was not able to reproduce the mark position issue you mention [here](https://github.com/googlefonts/noto-source/pull/379#issuecomment-851178647). This off-by-one error would be caused by the marks not being attached at all. This PR contains a regression test which shows that the text ວິດ does have the i-vowel correctly positioned over the wo.